### PR TITLE
fix: prevent hero title J from being clipped

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,7 +19,7 @@ import PhoneIcon from "@icons/PhoneIcon.astro";
       >
         <p class="eyebrow mb-5">Backend &amp; Full Stack Developer</p>
         <h1
-          class="text-5xl sm:text-6xl md:text-8xl font-black mb-6 playfair-display bg-clip-text text-transparent bg-gradient-to-r from-slate-100 to-slate-400"
+          class="text-5xl sm:text-6xl md:text-8xl font-black mb-6 leading-[1.2] sm:leading-[1.2] md:leading-[1.2] playfair-display bg-clip-text text-transparent bg-gradient-to-r from-slate-100 to-slate-400"
         >
           Julian Mican
         </h1>


### PR DESCRIPTION
## Summary
- The hero `<h1>` ("Julian Mican") uses Playfair Display Black with `bg-clip-text` for its gradient fill. Tailwind's `text-5xl/6xl/8xl` utilities bundle `line-height: 1`, which is shorter than this font's ascender height — so the top of the capital "J" got clipped to the gradient's paint box instead of just overflowing.
- Fixed by giving the heading a taller `line-height` (`leading-[1.2]`), repeated at each responsive breakpoint (`sm:`/`md:`) since Tailwind emits those text-size utilities in later media-query blocks, which otherwise re-applies `line-height: 1` and wins the cascade.

## Test plan
- [x] Verified in local dev preview (desktop, tablet, mobile widths) that the "J" renders fully, with no visual clipping
- [x] Confirmed no other layout shift/regression on the About page