### PR TITLE
content: add Global66 experience

### DIFF
--- a/src/components/ExperienceCards.astro
+++ b/src/components/ExperienceCards.astro
@@ -3,8 +3,19 @@ import Icons from "@icons/Icons.astro";
 
 const experiences = [
   {
+    title: "Global66",
+    time: "Currently, 4 months",
+    description:
+      'Senior Backend Developer working with <span class="text-white font-bold">Java</span> at a fintech — my first experience in the financial industry — building scalable services on <span class="text-white font-bold">AWS</span> backed by <span class="text-white font-bold">MySQL</span>.',
+    logos: [
+      { key: 0, svg: "JavaIcon" },
+      { key: 1, svg: "AwsIcon" },
+      { key: 2, svg: "MySqlIcon" },
+    ],
+  },
+  {
     title: "Farmatodo",
-    time: "Currently, 2 years",
+    time: "3 years 7 months",
     description:
       'Backend developer in <span class="text-white font-bold">Spring Boot</span> and <span class="text-white font-bold">NestJS</span>, developing new functionalities for microservices, working with <span class="text-white font-bold">OracleDB</span> and <span class="text-white font-bold">PostgreSQL</span>. Additionally, I excel in crafting <span class="text-white font-bold">Python</span> scripts for automation and data manipulation.',
     logos: [

--- a/tests/components/ExperienceCards.test.ts
+++ b/tests/components/ExperienceCards.test.ts
@@ -13,6 +13,7 @@ describe("ExperienceCards.astro", () => {
     const result = await container.renderToString(ExperienceCards);
 
     for (const title of [
+      "Global66",
       "Farmatodo",
       "Sophos Solutions",
       "ElTiempo",
@@ -21,7 +22,7 @@ describe("ExperienceCards.astro", () => {
     ]) {
       expect(result).toContain(title);
     }
-    expect(result).toContain("Currently, 2 years");
+    expect(result).toContain("Currently, 4 months");
   });
 
   it("ties hover glow and border colors to the living accent instead of a fixed violet", async () => {
@@ -46,6 +47,6 @@ describe("ExperienceCards.astro", () => {
     const result = await container.renderToString(ExperienceCards);
 
     const matches = result.match(/h-0\.5 w-12 accent-gradient/g) ?? [];
-    expect(matches.length).toBe(5);
+    expect(matches.length).toBe(6);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a new experience card for **Global66** — Senior Backend Developer, first fintech role, working with Java, AWS, and MySQL. Shown as the current position ("Currently, 4 months").
- Updates the **Farmatodo** card's duration badge from "Currently, 2 years" to "3 years 7 months", since it's no longer the current job.
- Updated the two `ExperienceCards` assertions that hardcoded the card count/current-role text.

## Test plan
- [x] `npm run test` — 70/70 passing
- [x] `npm run build` — passes
- [x] Verified `/experience` in the dev preview (accessibility snapshot): Global66 renders first with the correct description and Java/AWS/MySQL icons, Farmatodo no longer shows "Currently"